### PR TITLE
Clear Command Improvement?

### DIFF
--- a/commands/clear.js
+++ b/commands/clear.js
@@ -10,11 +10,11 @@ module.exports = {
     const channel = await interaction.channel;
 
     if (!interaction.member.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES)) {
-      return interaction.reply({ content: 'Non hai i permessi necessari.', ephemeral: true });
+      return interaction.reply({ content: '❌ Non hai i permessi necessari', ephemeral: true });
     }
 
     await channel.bulkDelete(quantity);
 
-    await interaction.reply({ content: 'Chat pulita.', ephemeral: true });
+    await interaction.reply({ content: '✅ Chat pulita.', ephemeral: true });
   },
 };

--- a/commands/clear.js
+++ b/commands/clear.js
@@ -10,11 +10,20 @@ module.exports = {
     const channel = await interaction.channel;
 
     if (!interaction.member.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES)) {
-      return interaction.reply({ content: '❌ Non hai i permessi necessari', ephemeral: true });
+      const errorEmbed = {
+        title: '❌ Si è verificato un errore',
+        description: 'Non hai i permessi necessari.',
+        color: '#FF0000',
+      };
+      return interaction.reply({ embeds: [errorEmbed], ephemeral: true });
     }
 
     await channel.bulkDelete(quantity);
 
-    await interaction.reply({ content: '✅ Chat pulita.', ephemeral: true });
+    const successEmbed = {
+      title: '✅ Chat pulita',
+      color: '#00FF00',
+    };
+    await interaction.reply({ embeds: [successEmbed], ephemeral: true });
   },
 };

--- a/commands/clear.js
+++ b/commands/clear.js
@@ -1,39 +1,20 @@
-const { SlashCommandBuilder, PermissionsBitField } = require('discord.js')
+const { SlashCommandBuilder, Permissions } = require('discord.js');
 
 module.exports = {
-	data: new SlashCommandBuilder()
-		.setName('clear')
-		.setDescription('Pulisci la chat')
-		.addIntegerOption((option) =>
-			option.setName('quantità').setDescription('La quantità di messaggi da rimuovere').setRequired(true)
-		),
-	async execute(interaction) {
-		const quantity = interaction.options.getInteger('quantità')
-		const channel = await interaction.channel
+  data: new SlashCommandBuilder()
+    .setName('clear')
+    .setDescription('Pulisci la chat')
+    .addIntegerOption(option => option.setName('quantità').setDescription('La quantità di messaggi da rimuovere').setRequired(true)),
+  async execute(interaction) {
+    const quantity = interaction.options.getInteger('quantità');
+    const channel = await interaction.channel;
 
-		if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
-			await interaction.reply({
-				embeds: [
-					{
-						title: `❌ Si è verificato un errore`,
-						description: `Non hai i permessi necessari`,
-						color: 15548997
-					}
-				],
-				ephemeral: true
-			})
-			return
-		}
+    if (!interaction.member.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES)) {
+      return interaction.reply({ content: 'Non hai i permessi necessari.', ephemeral: true });
+    }
 
-		await channel.bulkDelete(quantity)
+    await channel.bulkDelete(quantity);
 
-		await interaction.reply({
-			embeds: [
-				{
-					title: `✅ Chat pulita`,
-					color: 5763719
-				}
-			]
-		})
-	}
-}
+    await interaction.reply({ content: 'Chat pulita.', ephemeral: true });
+  },
+};


### PR DESCRIPTION
### Code from /commands/clear.js

**Translated from RUS to IT:**
Ciaooooo. 
Xanex ha controllato i comandi e ha scoperto che il comando "cancella" poteva essere migliorato. 
Non conosco nessun JS e lui non vuole spiegarmelo. 
Non so nemmeno se funziona, ma sembra a posto. 
Anche se non funziona forse puoi usarlo per ricodificare.

PermissionsBitField non è più utilizzato nell'ultima versione di Discord.js. 
Inoltre, abbiamo aggiunto wait quando si ottiene la proprietà interaction.channel per garantire che il canale venga risolto prima dell'esecuzione dell'operazione di eliminazione in blocco.

**ENG:**
Helooooo. Xanex checked out the commands and found out that the "clear" command could be improved. 
I don't know any JS and he dosnt wanna explain it to me. 
I don't even know if this works but it looks fine. 
Even if it dosn't work maybe you can use it to recode.

PermissionsBitField is no longer used in the latest version of Discord.js. 
Additionally, we've added await when getting the interaction.channel property to ensure that the channel is resolved before the bulk delete operation is executed.


_Sinceramente Xanex/Aspect
Sincerely Xanex/Aspect_